### PR TITLE
Implement Admin-Only Survey Creation with DTOs for Create & Retrieve

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -48,6 +48,20 @@
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 		</dependency>
+
+		<!-- Security so @PreAuthorize and SecurityFilterChain compile -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<!-- Bean Validation API + Hibernate Validator (for @NotBlank, @Size, etc.) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
+
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/training/feedbacktool/common/RestExceptionHandler.java
+++ b/backend/src/main/java/com/training/feedbacktool/common/RestExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.training.feedbacktool.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    // turn IllegalArgumentException (e.g., duplicate title) into HTTP 400
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", 400,
+                "error", ex.getMessage()
+        ));
+    }
+}

--- a/backend/src/main/java/com/training/feedbacktool/config/SecurityConfig.java
+++ b/backend/src/main/java/com/training/feedbacktool/config/SecurityConfig.java
@@ -1,0 +1,41 @@
+package com.training.feedbacktool.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    @Profile("dev")  // <--- This makes it run ONLY in the 'dev' profile
+    UserDetailsService users() {
+        UserDetails admin = User.withUsername("admin")
+                .password("{noop}admin") // {noop} = plain text for dev only
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(admin);
+    }
+}

--- a/backend/src/main/java/com/training/feedbacktool/repository/SurveyRepository.java
+++ b/backend/src/main/java/com/training/feedbacktool/repository/SurveyRepository.java
@@ -1,0 +1,8 @@
+package com.training.feedbacktool.repository;
+
+import com.training.feedbacktool.entity.Survey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+    boolean existsByTitleIgnoreCase(String title);
+}

--- a/backend/src/main/java/com/training/feedbacktool/survey/SurveyService.java
+++ b/backend/src/main/java/com/training/feedbacktool/survey/SurveyService.java
@@ -1,0 +1,51 @@
+package com.training.feedbacktool.survey;
+
+import com.training.feedbacktool.entity.Survey;
+import com.training.feedbacktool.repository.SurveyRepository;
+import com.training.feedbacktool.survey.api.dto.CreateSurveyRequest;
+import com.training.feedbacktool.survey.api.dto.SurveyResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SurveyService {
+
+    private final SurveyRepository repo;
+
+    public SurveyService(SurveyRepository repo) {
+        this.repo = repo;
+    }
+
+    @Transactional
+    public SurveyResponse create(CreateSurveyRequest req) {
+        // Unique title
+        if (repo.existsByTitleIgnoreCase(req.title())) {
+            throw new IllegalArgumentException("Survey title already exists");
+        }
+
+        // Build entity from request
+        Survey s = new Survey();
+        s.setTitle(req.title().trim());
+        s.setDescription(req.description());
+
+        // Map "active" (if provided) to your current "status" field
+        // default remains "DRAFT" as defined in the entity
+        if (Boolean.TRUE.equals(req.active())) {
+            s.setStatus("ACTIVE");
+        } else {
+            // if active == null or false, keep DRAFT (or set explicitly)
+            s.setStatus("DRAFT");
+        }
+
+        Survey saved = repo.save(s);
+
+        return new SurveyResponse(
+                saved.getId(),
+                saved.getTitle(),
+                saved.getDescription(),
+                saved.getStatus(),
+                saved.getCreatedAt(),
+                saved.getUpdatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/training/feedbacktool/survey/api/SurveyController.java
+++ b/backend/src/main/java/com/training/feedbacktool/survey/api/SurveyController.java
@@ -1,0 +1,32 @@
+package com.training.feedbacktool.survey.api;
+
+import com.training.feedbacktool.survey.SurveyService;
+import com.training.feedbacktool.survey.api.dto.CreateSurveyRequest;
+import com.training.feedbacktool.survey.api.dto.SurveyResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/surveys")
+public class SurveyController {
+
+    private final SurveyService service;
+
+    public SurveyController(SurveyService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/create")
+    @PreAuthorize("hasRole('ADMIN')") // Admin only
+    public ResponseEntity<SurveyResponse> create(@Valid @RequestBody CreateSurveyRequest req) {
+        SurveyResponse created = service.create(req);
+        return ResponseEntity.created(URI.create("/surveys/" + created.id())).body(created);
+    }
+}

--- a/backend/src/main/java/com/training/feedbacktool/survey/api/dto/CreateSurveyRequest.java
+++ b/backend/src/main/java/com/training/feedbacktool/survey/api/dto/CreateSurveyRequest.java
@@ -1,0 +1,10 @@
+package com.training.feedbacktool.survey.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSurveyRequest(
+        @NotBlank @Size(max = 150) String title,
+        @Size(max = 2000) String description,
+        Boolean active
+) {}

--- a/backend/src/main/java/com/training/feedbacktool/survey/api/dto/SurveyResponse.java
+++ b/backend/src/main/java/com/training/feedbacktool/survey/api/dto/SurveyResponse.java
@@ -1,0 +1,12 @@
+package com.training.feedbacktool.survey.api.dto;
+
+import java.time.Instant;
+
+public record SurveyResponse(
+        Long id,
+        String title,
+        String description,
+        String status,
+        Instant createdAt,
+        Instant updatedAt
+) {}


### PR DESCRIPTION
Added CreateSurveyRequest DTO for survey creation requests (title, description, status).
Added SurveyResponse DTO for returning survey details to clients.
Implemented POST /surveys/create endpoint (admin-only, with @PreAuthorize("hasRole('ADMIN')")).
Added basic validation on input (e.g., non-blank title).
Integrated SurveyService and SurveyRepository for persistence.
Added basic exception handling via RestExceptionHandler.
Configured SecurityConfig with in-memory admin user for development.