### PR TITLE
Refactoring backend files

### DIFF
--- a/backend/src/main/java/com/training/feedbacktool/controller/SurveyController.java
+++ b/backend/src/main/java/com/training/feedbacktool/controller/SurveyController.java
@@ -1,8 +1,8 @@
-package com.training.feedbacktool.survey.api;
+package com.training.feedbacktool.controller;
 
-import com.training.feedbacktool.survey.SurveyService;
-import com.training.feedbacktool.survey.api.dto.CreateSurveyRequest;
-import com.training.feedbacktool.survey.api.dto.SurveyResponse;
+import com.training.feedbacktool.service.SurveyService;
+import com.training.feedbacktool.dto.CreateSurveyRequest;
+import com.training.feedbacktool.dto.SurveyResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;

--- a/backend/src/main/java/com/training/feedbacktool/dto/CreateSurveyRequest.java
+++ b/backend/src/main/java/com/training/feedbacktool/dto/CreateSurveyRequest.java
@@ -1,4 +1,4 @@
-package com.training.feedbacktool.survey.api.dto;
+package com.training.feedbacktool.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;

--- a/backend/src/main/java/com/training/feedbacktool/dto/SurveyResponse.java
+++ b/backend/src/main/java/com/training/feedbacktool/dto/SurveyResponse.java
@@ -1,4 +1,4 @@
-package com.training.feedbacktool.survey.api.dto;
+package com.training.feedbacktool.dto;
 
 import java.time.Instant;
 

--- a/backend/src/main/java/com/training/feedbacktool/service/SurveyService.java
+++ b/backend/src/main/java/com/training/feedbacktool/service/SurveyService.java
@@ -1,9 +1,9 @@
-package com.training.feedbacktool.survey;
+package com.training.feedbacktool.service;
 
 import com.training.feedbacktool.entity.Survey;
 import com.training.feedbacktool.repository.SurveyRepository;
-import com.training.feedbacktool.survey.api.dto.CreateSurveyRequest;
-import com.training.feedbacktool.survey.api.dto.SurveyResponse;
+import com.training.feedbacktool.dto.CreateSurveyRequest;
+import com.training.feedbacktool.dto.SurveyResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
This pull request refactors the package structure for survey-related classes to improve code organization and maintainability. The main change is moving survey controller, service, and DTO classes out of the nested `survey` and `survey/api` packages into more general `controller`, `service`, and `dto` packages.

Package restructuring and file renaming:

**Survey controller and service:**
* Renamed and moved `SurveyController.java` from `survey/api` to `controller`, updating its package declaration and imports accordingly.
* Renamed and moved `SurveyService.java` from `survey` to `service`, updating its package declaration and imports accordingly.

**DTO classes:**
* Renamed and moved `CreateSurveyRequest.java` from `survey/api/dto` to `dto`, updating its package declaration.
* Renamed and moved `SurveyResponse.java` from `survey/api/dto` to `dto`, updating its package declaration.