### PR TITLE
implement user Entity and creation endpoint

### DIFF
--- a/backend/src/main/java/com/training/feedbacktool/config/SecurityConfig.java
+++ b/backend/src/main/java/com/training/feedbacktool/config/SecurityConfig.java
@@ -10,6 +10,8 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -23,14 +25,19 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
-                        .anyRequest().authenticated()
-                )
+                        .requestMatchers("/users/create").permitAll() // Allow unauthenticated user creation
+                        .anyRequest().authenticated())
                 .httpBasic(Customizer.withDefaults());
         return http.build();
     }
 
     @Bean
-    @Profile("dev")  // <--- This makes it run ONLY in the 'dev' profile
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Profile("dev") // <--- This makes it run ONLY in the 'dev' profile
     UserDetailsService users() {
         UserDetails admin = User.withUsername("admin")
                 .password("{noop}admin") // {noop} = plain text for dev only

--- a/backend/src/main/java/com/training/feedbacktool/controller/UserController.java
+++ b/backend/src/main/java/com/training/feedbacktool/controller/UserController.java
@@ -1,0 +1,31 @@
+package com.training.feedbacktool.controller;
+
+import com.training.feedbacktool.service.UserService;
+import com.training.feedbacktool.dto.CreateUserRequest;
+import com.training.feedbacktool.dto.UserResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    private final UserService service;
+
+    public UserController(UserService service) {
+        this.service = service;
+    }
+
+    @PostMapping("/create")
+    // Removed @PreAuthorize - now allows unauthenticated user creation
+    public ResponseEntity<UserResponse> create(@Valid @RequestBody CreateUserRequest req) {
+        UserResponse created = service.create(req);
+        return ResponseEntity.created(URI.create("/users/" + created.id())).body(created);
+    }
+}

--- a/backend/src/main/java/com/training/feedbacktool/dto/CreateUserRequest.java
+++ b/backend/src/main/java/com/training/feedbacktool/dto/CreateUserRequest.java
@@ -1,0 +1,16 @@
+package com.training.feedbacktool.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateUserRequest(
+        @NotBlank(message = "Email is required") @Email(message = "Email should be valid") String email,
+
+        @NotBlank(message = "Password is required") @Size(min = 6, message = "Password must be at least 6 characters") String password,
+
+        @NotBlank(message = "Name is required") String name
+
+// Removed role field - will use default from service
+) {
+}

--- a/backend/src/main/java/com/training/feedbacktool/dto/UserResponse.java
+++ b/backend/src/main/java/com/training/feedbacktool/dto/UserResponse.java
@@ -1,0 +1,11 @@
+package com.training.feedbacktool.dto;
+
+import java.time.Instant;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String name,
+        String role,
+        Instant createdAt) {
+}

--- a/backend/src/main/java/com/training/feedbacktool/entity/User.java
+++ b/backend/src/main/java/com/training/feedbacktool/entity/User.java
@@ -1,8 +1,40 @@
 package com.training.feedbacktool.entity;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
 
 @Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA requirement
+@AllArgsConstructor
+@Builder
 public class User {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String role;
+
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = Instant.now();
+    }
 }

--- a/backend/src/main/java/com/training/feedbacktool/repository/UserRepository.java
+++ b/backend/src/main/java/com/training/feedbacktool/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.training.feedbacktool.repository;
+
+import com.training.feedbacktool.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmailIgnoreCase(String email);
+}

--- a/backend/src/main/java/com/training/feedbacktool/service/UserService.java
+++ b/backend/src/main/java/com/training/feedbacktool/service/UserService.java
@@ -1,0 +1,50 @@
+package com.training.feedbacktool.service;
+
+import com.training.feedbacktool.entity.User;
+import com.training.feedbacktool.repository.UserRepository;
+import com.training.feedbacktool.dto.CreateUserRequest;
+import com.training.feedbacktool.dto.UserResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UserService {
+
+    private final UserRepository repo;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.user.default-role:USER}")
+    private String defaultRole;
+
+    public UserService(UserRepository repo, PasswordEncoder passwordEncoder) {
+        this.repo = repo;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    public UserResponse create(CreateUserRequest req) {
+        // Check if email already exists
+        if (repo.existsByEmailIgnoreCase(req.email())) {
+            throw new IllegalArgumentException("User with this email already exists");
+        }
+
+        // Build entity from request
+        User user = User.builder()
+                .email(req.email().trim().toLowerCase())
+                .passwordHash(passwordEncoder.encode(req.password()))
+                .name(req.name().trim())
+                .role(defaultRole.toUpperCase())
+                .build();
+
+        User saved = repo.save(user);
+
+        return new UserResponse(
+                saved.getId(),
+                saved.getEmail(),
+                saved.getName(),
+                saved.getRole(),
+                saved.getCreatedAt());
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.jpa.show.sql=true
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+app.registration.public=true
+app.user.default-role=USER
+app.user.default-admin=false


### PR DESCRIPTION
This pull request introduces user registration functionality to the backend, allowing unauthenticated users to create accounts. It adds new DTOs, controller, service, entity, and repository classes to support user creation, enforces validation, and ensures passwords are securely hashed. Security configuration is updated to permit public access to the registration endpoint.

**User Registration Feature**

* Added `UserController` with a `/users/create` endpoint that allows unauthenticated user creation; removed any pre-authorization requirements.
* Introduced `CreateUserRequest` and `UserResponse` DTOs for input validation and response formatting. The request enforces email, password, and name requirements, and omits role assignment (handled by the service). [[1]](diffhunk://#diff-5ba725fc0bb1047a20b53370c9befbf02196f19e3ad7fa8b2cdb2ac52c61ff78R1-R16) [[2]](diffhunk://#diff-22ad0961b762c95faf72e440c7ac1516d844954f1dcd210b20829e539a5fe9e5R1-R11)
* Implemented `UserService` to handle user creation: checks for duplicate emails, hashes passwords using the configured encoder, assigns a default role, and persists the new user.
* Created `UserRepository` for database access and email uniqueness checks.
* Defined the `User` entity with fields for email, password hash, name, role, and creation timestamp, using Lombok for boilerplate code.

**Security and Configuration Updates**

* Updated `SecurityConfig` to allow unauthenticated access to `/users/create`, added a `PasswordEncoder` bean for password hashing, and included properties for default role and registration settings. [[1]](diffhunk://#diff-c70ce24d59bbd637060cd4f108aca35b16d673e8d11434d9dfd6333b72218de8R13-R14) [[2]](diffhunk://#diff-c70ce24d59bbd637060cd4f108aca35b16d673e8d11434d9dfd6333b72218de8L26-R38) [[3]](diffhunk://#diff-b357bac448d6dbc289cd88013dbf9cc867b6f020f90752c84719856323bb6c0aR9-R11)